### PR TITLE
Add `no-dir` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ const cli = meow(`
 	  --parents            Preserve path structure
 	  --cwd=<dir>          Working directory for files
 	  --rename=<filename>  Rename all <source> filenames to <filename>
+	  --no-dir             Do not match directories
 
 	<source> can contain globs if quoted
 
@@ -20,7 +21,7 @@ const cli = meow(`
 	  $ cpy 'src/*.png' '!src/goat.png' dist
 
 	  Copy all .html files inside src folder into dist and preserve path structure
-	  $ cpy '**/*.html' '../dist/' --cwd=src --parents
+	  $ cpy '**/*.html' '../dist/' --cwd=src --parents --no-dir
 `, {
 	string: ['_']
 });
@@ -30,7 +31,8 @@ fn(cli.input, cli.input.pop(), {
 	rename: cli.flags.rename,
 	parents: cli.flags.parents,
 	overwrite: cli.flags.overwrite !== false,
-	nonull: true
+	nonull: true,
+	nodir: cli.flags.noDir !== false
 }).catch(err => {
 	if (err.name === 'CpyError') {
 		console.error(err.message);

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ $ cpy --help
     --parents            Preserve path structure
     --cwd=<dir>          Working directory for files
     --rename=<filename>  Rename all <source> filenames to <filename>
+    --no-dir             Do not match directories
 
   <source> can contain globs if quoted
 
@@ -39,7 +40,7 @@ $ cpy --help
     $ cpy 'src/*.png' '!src/goat.png' dist
 
     Copy all .html files inside src folder into dist and preserve path structure
-    $ cpy '**/*.html' '../dist/' --cwd=src --parents
+    $ cpy '**/*.html' '../dist/' --cwd=src --parents --no-dir
 ```
 
 


### PR DESCRIPTION
Related to https://github.com/sindresorhus/cpy/issues/10. When copying all files and directories in a directory you'll end up with a `EISDIR` failure. And since `nodir` wasn't passed there was no way to fix it.
