### PR TITLE
Update meow from 5.0.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	],
 	"dependencies": {
 		"cpy": "^8.0.0",
-		"meow": "^5.0.0"
+		"meow": "^6.1.1"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
meow v6.1.1 updates yargs-parser to v18.1.2 which fixes a prototype pollution vulnerability as as asserted by npm audit.

https://github.com/sindresorhus/meow/pull/137
https://github.com/sindresorhus/meow/pull/148