### PR TITLE
Update `cpy` to v9

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,10 +9,10 @@ const cli = meow(`
 
 	Options
 	  --no-overwrite       Don't overwrite the destination
-	  --parents            Preserve path structure
 	  --cwd=<dir>          Working directory for files
 	  --rename=<filename>  Rename all <source> filenames to <filename>
 	  --dot                Allow patterns to match entries that begin with a period (.)
+		--flat							 Flatten directory structure. All copied files will be put in the same directory.
 
 	<source> can contain globs if quoted
 
@@ -21,17 +21,13 @@ const cli = meow(`
 	  $ cpy 'src/*.png' '!src/goat.png' dist
 
 	  Copy all .html files inside src folder into dist and preserve path structure
-	  $ cpy '**/*.html' '../dist/' --cwd=src --parents
+	  $ cpy '.' '../dist/' --cwd=src
 `, {
 	importMeta: import.meta,
 	flags: {
 		overwrite: {
 			type: 'boolean',
 			default: true,
-		},
-		parents: {
-			type: 'boolean',
-			default: false,
 		},
 		cwd: {
 			type: 'string',
@@ -44,6 +40,10 @@ const cli = meow(`
 			type: 'boolean',
 			default: false,
 		},
+		flat: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 });
 
@@ -52,9 +52,9 @@ const cli = meow(`
 		await cpy(cli.input, cli.input.pop(), {
 			cwd: cli.flags.cwd,
 			rename: cli.flags.rename,
-			parents: cli.flags.parents,
 			overwrite: cli.flags.overwrite,
 			dot: cli.flags.dot,
+			flat: cli.flags.flat,
 		});
 	} catch (error) {
 		if (error.name === 'CpyError') {

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ const cli = meow(`
 	  --cwd=<dir>          Working directory for files
 	  --rename=<filename>  Rename all <source> filenames to <filename>
 	  --dot                Allow patterns to match entries that begin with a period (.)
-		--flat							 Flatten directory structure. All copied files will be put in the same directory.
+	  --flat               Flatten directory structure. All copied files will be put in the same directory.
 
 	<source> can contain globs if quoted
 
@@ -20,8 +20,8 @@ const cli = meow(`
 	  Copy all .png files in src folder into dist except src/goat.png
 	  $ cpy 'src/*.png' '!src/goat.png' dist
 
-	  Copy all .html files inside src folder into dist and preserve path structure
-	  $ cpy '.' '../dist/' --cwd=src
+	  Copy all files inside src folder into dist and preserve path structure
+	  $ cpy . '../dist/' --cwd=src
 `, {
 	importMeta: import.meta,
 	flags: {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"contents"
 	],
 	"dependencies": {
-		"cpy": "^8.1.2",
+		"cpy": "^9.0.0",
 		"meow": "^10.1.2"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ $ cpy --help
     --cwd=<dir>          Working directory for files
     --rename=<filename>  Rename all <source> filenames to <filename>
     --dot                Allow patterns to match entries that begin with a period (.)
-		--flat							 Flatten directory structure. All copied files will be put in the same directory.
+    --flat               Flatten directory structure. All copied files will be put in the same directory.
 
   <source> can contain globs if quoted
 
@@ -36,8 +36,8 @@ $ cpy --help
     Copy all .png files in src folder into dist except src/goat.png
     $ cpy 'src/*.png' '!src/goat.png' dist
 
-    Copy all .html files inside src folder into dist and preserve path structure
-    $ cpy '.' '../dist/' --cwd=src
+    Copy all files inside src folder into dist and preserve path structure
+    $ cpy . '../dist/' --cwd=src
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,10 @@ $ cpy --help
 
   Options
     --no-overwrite       Don't overwrite the destination
-    --parents            Preserve path structure
     --cwd=<dir>          Working directory for files
     --rename=<filename>  Rename all <source> filenames to <filename>
     --dot                Allow patterns to match entries that begin with a period (.)
+		--flat							 Flatten directory structure. All copied files will be put in the same directory.
 
   <source> can contain globs if quoted
 
@@ -37,7 +37,7 @@ $ cpy --help
     $ cpy 'src/*.png' '!src/goat.png' dist
 
     Copy all .html files inside src folder into dist and preserve path structure
-    $ cpy '**/*.html' '../dist/' --cwd=src --parents
+    $ cpy '.' '../dist/' --cwd=src
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -29,14 +29,18 @@ test('cwd', async t => {
 	t.is(read(t.context.tmp, 'cwd/hello.js'), read(t.context.tmp, 'cwd/dest/hello.js'));
 });
 
-test('keep path structure with flag `--parents`', async t => {
+test('path structure', async t => {
 	fs.mkdirSync(t.context.tmp);
 	fs.mkdirSync(path.join(t.context.tmp, 'cwd'));
+	fs.mkdirSync(path.join(t.context.tmp, 'out'));
 	fs.writeFileSync(path.join(t.context.tmp, 'cwd/hello.js'), 'console.log("hello");');
 
-	await execa('./cli.js', [path.join(t.context.tmp, 'cwd/hello.js'), t.context.tmp, '--parents']);
+	await execa('./cli.js', [path.join(t.context.tmp, '**'), path.join(t.context.tmp, 'out')]);
 
-	t.is(read(t.context.tmp, 'cwd/hello.js'), read(t.context.tmp, t.context.tmp, 'cwd/hello.js'));
+	t.is(
+		read(t.context.tmp, 'cwd/hello.js'),
+		read(t.context.tmp, 'out/cwd/hello.js'),
+	);
 });
 
 test('rename filenames but not filepaths', async t => {
@@ -68,9 +72,32 @@ test('do not copy files in the negated glob patterns', async t => {
 	fs.writeFileSync(path.join(t.context.tmp, 'src/hello.jsx'), 'console.log("world");');
 	fs.writeFileSync(path.join(t.context.tmp, 'src/hello.es2015'), 'console.log("world");');
 
-	await execa('./cli.js', ['src/*.*', '!src/*.jsx', '!src/*.es2015', 'dest', '--cwd', t.context.tmp]);
+	await execa('./cli.js', ['src/*.*', '!src/*.jsx', '!src/*.es2015', path.join(t.context.tmp, 'dest'), '--cwd', t.context.tmp]);
 
 	t.is(read(t.context.tmp, 'dest/hello.js'), 'console.log("hello");');
 	t.false(pathExistsSync(path.join(t.context.tmp, 'dest/hello.jsx')));
 	t.false(pathExistsSync(path.join(t.context.tmp, 'dest/hello.es2015')));
+});
+
+test('flatten directory tree', async t => {
+	fs.mkdirSync(t.context.tmp);
+	fs.mkdirSync(path.join(t.context.tmp, 'source'));
+	fs.mkdirSync(path.join(t.context.tmp, 'source', 'nested'));
+	fs.writeFileSync(path.join(t.context.tmp, 'foo.js'), 'console.log("foo");');
+	fs.writeFileSync(path.join(t.context.tmp, 'source/bar.js'), 'console.log("bar");');
+	fs.writeFileSync(path.join(t.context.tmp, 'source/nested/baz.ts'), 'console.log("baz");');
+
+	await execa('./cli.js', ['**/*.js', 'destination/subdir', '--cwd', t.context.tmp, '--flat']);
+
+	t.is(
+		read(t.context.tmp, 'foo.js'),
+		read(t.context.tmp, 'destination/subdir/foo.js'),
+	);
+	t.is(
+		read(t.context.tmp, 'source/bar.js'),
+		read(t.context.tmp, 'destination/subdir/bar.js'),
+	);
+	t.falsy(
+		fs.existsSync(path.join(t.context.tmp, 'destination/subdir/baz.ts')),
+	);
 });


### PR DESCRIPTION
As pointed out in #32, glob-parent reports a high vulnerability through npm audit.  Since this has been addressed in cpy v9.0.0, this PR updates to v9.

Brief description of changes:
* Update cpy to v9.0.0
* Update cli.js to use new `--flat` flag
* Add documentation examples; remove references to deprecated flags
* Add tests (two copied from cpy) and update to conform to v9

Please let me know if you'd prefer any changes to tests, documentation, or have any questions.

Fixes #32 
Fixes #27