### PR TITLE
Add `--concurrency` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const cli = meow(`
 	  --rename=<filename>  Rename all <source> filenames to <filename>
 	  --dot                Allow patterns to match entries that begin with a period (.)
 	  --flat               Flatten directory structure. All copied files will be put in the same directory.
-	  --concurrency        Number of files being copied concurrently.
+	  --concurrency        Number of files being copied concurrently
 
 	<source> can contain globs if quoted
 

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import os from 'node:os';
 import meow from 'meow';
 import cpy from 'cpy';
 
@@ -44,6 +45,10 @@ const cli = meow(`
 			type: 'boolean',
 			default: false,
 		},
+		concurrency: {
+			type: 'number',
+			default: (os.cpus().length || 1) * 2,
+		},
 	},
 });
 
@@ -55,6 +60,7 @@ const cli = meow(`
 			overwrite: cli.flags.overwrite,
 			dot: cli.flags.dot,
 			flat: cli.flags.flat,
+			concurrency: cli.flags.concurrency,
 		});
 	} catch (error) {
 		if (error.name === 'CpyError') {

--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ const cli = meow(`
 		},
 		concurrency: {
 			type: 'number',
-			default: (os.cpus().length || 1) * 2,
+			default: (os.cpus().length > 0 ? os.cpus().length : 1) * 2,
 		},
 	},
 });

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ const cli = meow(`
 	  --rename=<filename>  Rename all <source> filenames to <filename>
 	  --dot                Allow patterns to match entries that begin with a period (.)
 	  --flat               Flatten directory structure. All copied files will be put in the same directory.
+	  --concurrency        Number of files being copied concurrently.
 
 	<source> can contain globs if quoted
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ $ cpy --help
     --rename=<filename>  Rename all <source> filenames to <filename>
     --dot                Allow patterns to match entries that begin with a period (.)
     --flat               Flatten directory structure. All copied files will be put in the same directory.
-    --concurrency        Number of files being copied concurrently.
+    --concurrency        Number of files being copied concurrently
 
   <source> can contain globs if quoted
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ $ cpy --help
     --rename=<filename>  Rename all <source> filenames to <filename>
     --dot                Allow patterns to match entries that begin with a period (.)
     --flat               Flatten directory structure. All copied files will be put in the same directory.
+    --concurrency        Number of files being copied concurrently.
 
   <source> can contain globs if quoted
 


### PR DESCRIPTION
Fixes #21.

I'm not sure I need to write test codes about this flag, so I tried to simply benchmark the option using [hyperfine](https://github.com/sharkdp/hyperfine).

`os.cpus().length` on my local computer is `16`.

Here are the benchmark results.

```shell-script
$ hyperfine --runs 10 'node ./cli.js ./node_modules ./abc_node_modules' > result1
```

```
Benchmark 1: node ./cli.js ./node_modules ./abc_node_modules
  Time (mean ± σ):      5.029 s ±  0.919 s    [User: 5.521 s, System: 5.258 s]
  Range (min … max):    3.665 s …  6.315 s    10 runs
```

```shell-script
$ hyperfine --runs 10 'node ./cli.js ./node_modules ./abc_node_modules --concurrency=4' > result2
```

```
Benchmark 1: node ./cli.js ./node_modules ./abc_node_modules --concurrency=4
  Time (mean ± σ):      5.739 s ±  1.223 s    [User: 6.431 s, System: 5.027 s]
  Range (min … max):    4.451 s …  7.475 s    10 runs
```

If I need to do other things, I appreciate your letting me know.


