### PR TITLE
The `--rename` flag supports string templates.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -55,6 +55,12 @@ const cli = meow(`
 
 (async () => {
 	try {
+		const {rename} = cli.flags;
+		const renameReg = /{{(\s*)?basename(\s*)?}}/;
+		if (rename && renameReg.test(rename)) {
+			cli.flags.rename = basename => rename.replace(renameReg, basename);
+		}
+
 		await cpy(cli.input, cli.input.pop(), {
 			cwd: cli.flags.cwd,
 			rename: cli.flags.rename,

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ const cli = meow(`
 	Options
 	  --no-overwrite       Don't overwrite the destination
 	  --cwd=<dir>          Working directory for files
-	  --rename=<filename>  Rename all <source> filenames to <filename>
+	  --rename=<filename>  Rename all <source> filenames to <filename>, supports string templates.
 	  --dot                Allow patterns to match entries that begin with a period (.)
 	  --flat               Flatten directory structure. All copied files will be put in the same directory.
 	  --concurrency        Number of files being copied concurrently
@@ -24,6 +24,9 @@ const cli = meow(`
 
 	  Copy all files inside src folder into dist and preserve path structure
 	  $ cpy . '../dist/' --cwd=src
+
+	  Copy all .png files in the src folder to dist and prefix the image filenames.
+	  $ cpy 'src/*.png' dist --cwd=src --rename=hi-{{basename}}
 `, {
 	importMeta: import.meta,
 	flags: {

--- a/cli.js
+++ b/cli.js
@@ -56,9 +56,9 @@ const cli = meow(`
 (async () => {
 	try {
 		const {rename} = cli.flags;
-		const renameReg = /{{(\s*)?basename(\s*)?}}/;
+		const renameRegExp = /{{(\s*)?basename(\s*)?}}/;
 		if (rename && renameReg.test(rename)) {
-			cli.flags.rename = basename => rename.replace(renameReg, basename);
+			cli.flags.rename = basename => rename.replace(renameRegExp, basename);
 		}
 
 		await cpy(cli.input, cli.input.pop(), {

--- a/cli.js
+++ b/cli.js
@@ -59,9 +59,9 @@ const cli = meow(`
 (async () => {
 	try {
 		const {rename} = cli.flags;
-		const renameRegExp = /{{(\s*)?basename(\s*)?}}/;
-		if (rename && renameReg.test(rename)) {
-			cli.flags.rename = basename => rename.replace(renameRegExp, basename);
+		const stringTemplate = '{{basename}}';
+		if (rename && rename.includes(stringTemplate)) {
+			cli.flags.rename = basename => rename.replace(stringTemplate, basename);
 		}
 
 		await cpy(cli.input, cli.input.pop(), {

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ $ cpy --help
   Options
     --no-overwrite       Don't overwrite the destination
     --cwd=<dir>          Working directory for files
-    --rename=<filename>  Rename all <source> filenames to <filename>
+    --rename=<filename>  Rename all <source> filenames to <filename>, supports string templates.
     --dot                Allow patterns to match entries that begin with a period (.)
     --flat               Flatten directory structure. All copied files will be put in the same directory.
     --concurrency        Number of files being copied concurrently
@@ -39,6 +39,9 @@ $ cpy --help
 
     Copy all files inside src folder into dist and preserve path structure
     $ cpy . '../dist/' --cwd=src
+
+    Copy all .png files in the src folder to dist and prefix the image filenames.
+    $ cpy 'src/*.png' dist --cwd=src --rename=hi-{{basename}}
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -51,6 +51,9 @@ test('rename filenames but not filepaths', async t => {
 	await execa('./cli.js', [path.join(t.context.tmp, 'hello.js'), path.join(t.context.tmp, 'dest'), '--rename=hi.js']);
 
 	t.is(read(t.context.tmp, 'hello.js'), read(t.context.tmp, 'dest/hi.js'));
+
+	await execa('./cli.js', [path.join(t.context.tmp, 'hello.js'), path.join(t.context.tmp, 'dest'), '--rename=hi-{{basename}}-1']);
+	t.is(read(t.context.tmp, 'hello.js'), read(t.context.tmp, 'dest/hi-hello-1.js'));
 });
 
 test('overwrite files by default', async t => {


### PR DESCRIPTION
```bash
$ cpy 'src/*.png' dist --rename 'hi-{{basename}}'
```

output

```
hi-apple.png
```

This is an enhancement feature

@sindresorhus 